### PR TITLE
feat(fix): refactor OTP flow and improve user registration checks

### DIFF
--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -4,7 +4,7 @@ export interface IApiResponse<T> {
 	status: 'SUCCESS' | 'ERROR';
 	msg: string;
 	data: T;
-	statusCode: 200 | 201 | 401;
+	statusCode: 200 | 201 | 401 | 500;
 }
 export interface IPermissionType {
 	id: number;


### PR DESCRIPTION
Refactored the OTP sending logic to use axios and simplified the getOtpAction server action. Moved user registration checks to the login page client-side, ensuring only registered users can request OTP for login, while registration page now triggers OTP sending via the same action. Updated IApiResponse to include statusCode 500 for better error handling.